### PR TITLE
Adding rendered_html method to display html in Databricks notebook

### DIFF
--- a/spark_df_profiling/__init__.py
+++ b/spark_df_profiling/__init__.py
@@ -58,15 +58,17 @@ class ProfileReport(object):
         return variable_profile.index[variable_profile.correlation > threshold].tolist()
 
     def to_file(self, outputfile=DEFAULT_OUTPUTFILE):
-
         if outputfile != NO_OUTPUTFILE:
             if outputfile == DEFAULT_OUTPUTFILE:
                 outputfile = 'profile_' + str(hash(self)) + ".html"
 
             self.file = codecs.open(outputfile, 'w+b', encoding='utf8')
             # TODO: should be done in the template
-            self.file.write(template('wrapper').render(content=self.html))
+            self.file.write(self.rendered_html())
             self.file.close()
+
+    def rendered_html(self):
+        return template('wrapper').render(content=self.html)
 
     def _repr_html_(self):
         return self.html


### PR DESCRIPTION
The existing `ProfileReport.render_standalone` seems to error on in rendering HTML in javascript code.

![image](https://user-images.githubusercontent.com/6900999/50263146-3db39580-03c9-11e9-8c70-e26a248b50e6.png)

However using the logic in `ProfileReport.to_file` like below, works in Databricks notebook. Adding a method to render displayable HTML

![image](https://user-images.githubusercontent.com/6900999/50263213-8c612f80-03c9-11e9-8098-f0fb4bcb9474.png)

---

With the fix, displaying report should work like so

```
import spark_df_profiling

report = spark_df_profiling.ProfileReport(df)
displayHTML(report.rendered_html())
```
