### PR TITLE
tslib removed from base

### DIFF
--- a/spark_df_profiling/base.py
+++ b/spark_df_profiling/base.py
@@ -320,7 +320,7 @@ def describe(df, bins, corr_reject, config, **kwargs):
         stats.name = column
 
         # Convert Pandas timestamp object to regular datetime:
-        if isinstance(stats["max"], pd.tslib.Timestamp):
+        if isinstance(stats["max"], pd.Timestamp):
             stats = stats.astype(object)
             stats["max"] = str(stats["max"].to_pydatetime())
             stats["min"] = str(stats["min"].to_pydatetime())


### PR DESCRIPTION
Issue #26 is resolved with this bug fix. 
The problem is the tslib part of pandas which has moved, hence 'pd.tslib.Timestamp' cannot be used but instead you can simply import 'pd.Timestamp'. 